### PR TITLE
fix docker and docker-compose, add traefik setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,50 @@ meteor
 The app now runs with an empty database on http://localhost:3000
 
 ### Deployment
+This app can be easily hosted using docker-compose.
 
-This app can be easily deployed using docker-compose.
+#### Preparation: install docker-compose
+
 If you haven't installed Docker and Docker Compose already, check the official
 documentation for the installation details:
 [Docker](https://docs.docker.com/install/) and
 [Docker Compose](https://docs.docker.com/compose/install/).
 
+#### Preparation: docker network
+Create the web network with the following command:
+```
+docker network create web
+```
+
+#### Run epiph
 ```
 git clone https://github.com/TeamEpiph/epiph.git
+
 cd epiph/app
-docker-compose up
+
+vi docker-compose.yml # adapt traefik.basic.frontend.rule to your domain
+docker-compose up -d
 ```
+Now epiph is running on http://localhost:3000
+If you want to expose the service to the public via a domain, follow the next steps.
+
+#### External Access and HTTPS
+Make sure port 80 and 443 are accessible from external and that you set up DNS
+correctly. The domain name you are going to specify needs to resolve to your IP.
+Traefik is going to request an TLS certificate from Let's Encrypt and
+needs these ports to be available in order to verify the request.
+
+```
+cd epiph/traefik
+touch acme.json && chmod 600 acme.json
+cp traefik.toml.example traefik.toml
+vi traefik.toml # set domain and email
+
+docker-compose up -d
+```
+
+The app should be up on the domain you specified eg. https://epiph.ch
+
 
 ### Default User for login to epiph
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+docker-data/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -20,16 +20,21 @@ USER meteor
 
 COPY --chown=meteor:staff . /home/meteor/src
 
-RUN cd /home/meteor/src && \
-  curl https://install.meteor.com | sh && \
-  /home/meteor/.meteor/meteor npm install --production && \
-  mkdir -p /home/meteor && \
-  /home/meteor/.meteor/meteor build --directory /home/meteor && \
-  rm -rf /home/meteor/.meteor && \
-  cd /home/meteor/bundle/programs/server && \
-  npm install
+# install meteor
+RUN curl https://install.meteor.com | sh
 
-WORKDIR /home/meteor/bundle
+# build the app
+RUN cd /home/meteor/src && \
+  npm install --production && \
+  mkdir -p /home/meteor/build && \
+  /home/meteor/.meteor/meteor build --directory /home/meteor/build && \
+  cd /home/meteor/build/bundle/programs/server && \
+  npm install --production
+
+# cleanup
+RUN rm -rf /home/meteor/.meteor
+
+WORKDIR /home/meteor/build/bundle
 
 EXPOSE 3000
 ENV PORT 3000

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "3000"
     links:
       - mongo
+    depends_on:
+      - mongo
     environment:
       MONGO_URL: mongodb://mongo:27017/epiph
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -22,3 +22,5 @@ services:
       - "27017:27017"
     expose:
       - "27017"
+    volumes:
+      - ./docker-data/mongo:/data/db

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -16,6 +16,15 @@ services:
       - mongo
     environment:
       MONGO_URL: mongodb://mongo:27017/epiph
+    networks:
+      - web
+      - default
+    labels:
+      - "traefik.docker.network=web"
+      - "traefik.enable=true"
+      - "traefik.basic.frontend.rule=Host:epiph.ch"
+      - "traefik.basic.port=3000"
+      - "traefik.basic.protocol=http"
 
   mongo:
     image: mongo:latest
@@ -26,3 +35,7 @@ services:
       - "27017"
     volumes:
       - ./docker-data/mongo:/data/db
+
+networks:
+  web:
+    external: true

--- a/traefik/.gitignore
+++ b/traefik/.gitignore
@@ -1,0 +1,2 @@
+traefik.toml
+acme.json

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+services:
+  traefik:
+    image: traefik:1.7
+    restart: always
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - web
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik.toml:/traefik.toml
+      - ./acme.json:/acme.json
+    container_name: traefik
+
+networks:
+  web:
+    external: true
+

--- a/traefik/traefik.toml.example
+++ b/traefik/traefik.toml.example
@@ -1,0 +1,29 @@
+debug = false
+
+logLevel = "ERROR"
+defaultEntryPoints = ["https","http"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+  [entryPoints.https.tls]
+
+[retry]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "my-awesome-app.org"
+watch = true
+exposedByDefault = false
+
+[acme]
+email = "your-email-here@my-awesome-app.org"
+storage = "acme.json"
+entryPoint = "https"
+onHostRule = true
+[acme.httpChallenge]
+entryPoint = "http"


### PR DESCRIPTION
This PR fixes some issues with the Dockerfile and docker-compose. The app should now build like described in the Readme and docker-compose works as a production hosting solution.
It also adds a turn-key solution to setup HTTPS.

- [x] fix: building docker image
- [x] fix: make mongo data persistent across reboots
- [x] fix: resolve statup issue when mongo is not yet ready
- [x] feat: HTTPS setup using traefik